### PR TITLE
docs(README.md) adjust go version to build etcd-ca

### DIFF
--- a/README.md
+++ b/README.md
@@ -81,7 +81,7 @@ bob: Unsigned
 
 ### Building
 
-etcd-ca must be built with Go 1.2+. You can build etcd-ca from source:
+etcd-ca must be built with Go 1.3+. You can build etcd-ca from source:
 
 ```
 $ git clone https://github.com/coreos/etcd-ca


### PR DESCRIPTION
Adjust the go version to 1.3 which is needed to build etcd-ca see [#48](https://github.com/coreos/etcd-ca/issues/48)