### PR TITLE
When providing no passphrase, don't encrypt the key.

### DIFF
--- a/cmd/new_cert.go
+++ b/cmd/new_cert.go
@@ -83,7 +83,13 @@ func newCertAction(c *cli.Context) {
 	if err = depot.PutCertificateSigningRequest(d, name, csr); err != nil {
 		fmt.Fprintln(os.Stderr, "Save certificate request error:", err)
 	}
-	if err = depot.PutEncryptedPrivateKeyHost(d, name, key, passphrase); err != nil {
-		fmt.Fprintln(os.Stderr, "Save key error:", err)
+	if len(passphrase) == 0 {
+		if err = depot.PutPrivateKeyHost(d, name, key); err != nil {
+			fmt.Fprintln(os.Stderr, "Save key error:", err)
+		}
+	} else {
+		if err = depot.PutEncryptedPrivateKeyHost(d, name, key, passphrase); err != nil {
+			fmt.Fprintln(os.Stderr, "Save key error:", err)
+		}
 	}
 }


### PR DESCRIPTION
This was annoying as it has a different behavior than OpenSSL.  If you added no password, the key was still encrypted, which made streamlining certain processes much harder.
 
Would fix https://github.com/coreos/etcd-ca/issues/44