### PR TITLE
sign: allow to restrict usage of the signed certificate

### DIFF
--- a/cmd/sign.go
+++ b/cmd/sign.go
@@ -31,6 +31,8 @@ func NewSignCommand() cli.Command {
 		Flags: []cli.Flag{
 			cli.StringFlag{"passphrase", "", "Passphrase to decrypt private-key PEM block of CA", ""},
 			cli.IntFlag{"years", 10, "How long until the certificate expires", ""},
+			cli.BoolTFlag{"server", "Allow server authentication", ""},
+			cli.BoolTFlag{"client", "Allow client authentication", ""},
 		},
 		Action: newSignAction,
 	}
@@ -72,7 +74,7 @@ func newSignAction(c *cli.Context) {
 		os.Exit(1)
 	}
 
-	crtHost, err := pkix.CreateCertificateHost(crt, info, key, csr, c.Int("years"))
+	crtHost, err := pkix.CreateCertificateHost(crt, info, key, csr, c.Int("years"), c.Bool("server"), c.Bool("client"))
 	if err != nil {
 		fmt.Fprintln(os.Stderr, "Create certificate error:", err)
 		os.Exit(1)

--- a/pkix/cert_host.go
+++ b/pkix/cert_host.go
@@ -60,7 +60,7 @@ var (
 
 // CreateCertificateHost creates certificate for host.
 // The arguments include CA certificate, CA certificate info, CA key, certificate request.
-func CreateCertificateHost(crtAuth *Certificate, info *CertificateAuthorityInfo, keyAuth *Key, csr *CertificateSigningRequest, years int) (*Certificate, error) {
+func CreateCertificateHost(crtAuth *Certificate, info *CertificateAuthorityInfo, keyAuth *Key, csr *CertificateSigningRequest, years int, serverAuth, clientAuth bool) (*Certificate, error) {
 	hostTemplate.SerialNumber.Set(info.SerialNumber)
 	info.IncSerialNumber()
 
@@ -72,6 +72,14 @@ func CreateCertificateHost(crtAuth *Certificate, info *CertificateAuthorityInfo,
 	hostTemplate.Subject = rawCsr.Subject
 
 	hostTemplate.NotAfter = time.Now().AddDate(years, 0, 0).UTC()
+
+	hostTemplate.ExtKeyUsage = []x509.ExtKeyUsage{}
+	if serverAuth {
+		hostTemplate.ExtKeyUsage = append(hostTemplate.ExtKeyUsage, x509.ExtKeyUsageServerAuth)
+	}
+	if clientAuth {
+		hostTemplate.ExtKeyUsage = append(hostTemplate.ExtKeyUsage, x509.ExtKeyUsageClientAuth)
+	}
 
 	hostTemplate.SubjectKeyId, err = GenerateSubjectKeyId(rawCsr.PublicKey)
 	if err != nil {


### PR DESCRIPTION
Call "etcd-ca sign --server=false myclient1" to generate a client-only certificate. Similarly, set --client=false for certificates that are only valid for server authentication.